### PR TITLE
fix: adjust drizzle-orm related types

### DIFF
--- a/backend/src/routes/getBalance.ts
+++ b/backend/src/routes/getBalance.ts
@@ -17,14 +17,13 @@ export function getBalanceRoute(fastify: FastifyInstance) {
 
     try {
       // Use Drizzle ORM to find the balance by address
-      let balanceRecord = await fastify.db.query.usdcBalance
+      const balanceRecord = await fastify.db.query.usdcBalance
         .findFirst({ where: eq(usdcBalance.address, address) })
         .execute();
-      if (!balanceRecord) {
-        balanceRecord = { balance: '0' };
-      }
 
-      return reply.send({ balance: balanceRecord.balance });
+      const balance = balanceRecord?.balance ?? '0';
+
+      return reply.send({ balance });
     } catch (error) {
       console.error(error);
       return reply.status(500).send({ message: 'Internal server error' });

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -1,6 +1,4 @@
-import type { Database } from '../db/plugin';
-import type { db } from './db';
-import type { Redis } from './utils';
+import type { Database } from '../db/drizzle';
 
 declare module 'fastify' {
   interface FastifyInstance {

--- a/backend/test/getTransactionHistory.test.ts
+++ b/backend/test/getTransactionHistory.test.ts
@@ -48,7 +48,9 @@ function generateMockData(
     }
   }
 
-  return mockData;
+  // Silence the type error since it's an helper for testing.
+  // The issue is that `transferId` is a required field for inserting data.
+  return mockData as (typeof schema.usdcTransfer.$inferInsert)[];
 }
 
 describe('GET /transaction history route', () => {


### PR DESCRIPTION
This PR fixes types related to drizzle-orm, which means now autocomplete on `fastify.db` will work!
